### PR TITLE
Update `hast-to-hyperscript`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "has": "^1.0.1",
-    "hast-to-hyperscript": "^2.0.1"
+    "hast-to-hyperscript": "^3.0.0"
   },
   "devDependencies": {
     "hastscript": "^3.0.1",


### PR DESCRIPTION
Hi! 👋

`hast-to-hyperscript` was a but buggy (see https://github.com/mapbox/remark-react/issues/41), and should be much better now!