### PR TITLE
Update 'hast-to-hyperscript'

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "has": "^1.0.1",
-    "hast-to-hyperscript": "^3.0.0"
+    "hast-to-hyperscript": ">=3.0.1"
   },
   "devDependencies": {
     "hastscript": "^3.0.1",


### PR DESCRIPTION
I think it's better to follow dependencies `hast-to-hyperscript` updated to `3.0.1`.
syntax-tree/hast-to-hyperscript#4

Until this merge, hth couldn't detect `h` as `React.createElement` in enviroment `NODE_ENV === 'production'` . So style information was propsed to `React` as string not object.

And the issue has been fixed, I create PR `"^3.0.0"` => `">=3.0.1"`

P.S. `rehype-react`'s latest version on github is `3.0.1` but on [npm](https://www.npmjs.com/package/rehype-react) it remains as `3.0.0`. im not sure, so left as it.