### PR TITLE
fix(table): Use hast-util-table-cell-style to adjust align properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 /* Dependencies. */
 var has = require('has');
 var toH = require('hast-to-hyperscript');
+var tableCellStyle = require('@mapbox/hast-util-table-cell-style');
 
 /* Expose `rehype-react`. */
 module.exports = rehype2react;
@@ -41,7 +42,9 @@ function rehype2react(options) {
       }
     }
 
-    return toH(h, node, settings.prefix);
+    var hast = tableCellStyle(node);
+
+    return toH(h, hast, settings.prefix);
   }
 
   /* Wrap `createElement` to pass components in. */

--- a/index.js
+++ b/index.js
@@ -42,9 +42,7 @@ function rehype2react(options) {
       }
     }
 
-    var hast = tableCellStyle(node);
-
-    return toH(h, hast, settings.prefix);
+    return toH(h, tableCellStyle(node), settings.prefix);
   }
 
   /* Wrap `createElement` to pass components in. */

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "rhysd <lin90162@yahoo.co.jp>"
   ],
   "dependencies": {
+    "@mapbox/hast-util-table-cell-style": "^0.1.3",
     "has": "^1.0.1",
     "hast-to-hyperscript": "^5.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -115,7 +115,7 @@ test('React ' + React.version, function (t) {
         React.createElement('th', {style: {textAlign: 'right'}, key: 'h-3'}, undefined)
       ])
     ]),
-    'should transform an element with align propperty'
+    'should transform an element with align property'
   );
 
   t.end();

--- a/test.js
+++ b/test.js
@@ -108,5 +108,15 @@ test('React ' + React.version, function (t) {
     'should support components'
   );
 
+  t.deepEqual(
+    processor.stringify(h('table', {}, [h('thead', h('th', {align: 'right'}))])),
+    React.createElement('table', {key: 'h-1'}, [
+      React.createElement('thead', {key: 'h-2'}, [
+        React.createElement('th', {style: {textAlign: 'right'}, key: 'h-3'}, undefined)
+      ])
+    ]),
+    'should transform an element with align propperty'
+  );
+
   t.end();
 });


### PR DESCRIPTION
It transforms deprecated styling attributes on HAST table cells to inline styles like remark-react so that table aligns work properly.